### PR TITLE
#67 Trend Yaxis labels

### DIFF
--- a/src/common/labelFormatters.js
+++ b/src/common/labelFormatters.js
@@ -1,5 +1,7 @@
+import * as lodashString from 'lodash/string';
+
 // formats the label for the geographic type
-const entityTypeDisplay = entityType => {
+export const entityTypeDisplay = (entityType, prettycase) => {
   if (entityType === 'nypd_precinct') {
     return 'NYPD Precinct';
   }
@@ -8,7 +10,8 @@ const entityTypeDisplay = entityType => {
     entityType !== 'borough' &&
     entityType !== 'community_board'
   ) {
-    return entityType.replace(/_/g, ' ');
+    const typename = entityType.replace(/_/g, ' ');
+    return prettycase ? lodashString.startCase(lodashString.camelCase(typename)) : typename;
   }
   return '';
 };
@@ -33,6 +36,16 @@ export const entityIdDisplay = (entityType, id) => {
   }
 
   return id;
+};
+
+export const REFERENCE_ENTITY_NAMES = {
+  citywide: 'Citywide',
+  custom: 'Custom Geography',
+  manhattan: 'Manhattan',
+  bronx: 'The Bronx',
+  brooklyn: 'Brooklyn',
+  queens: 'Queens',
+  'staten island': 'Staten Island',
 };
 
 export default entityTypeDisplay;

--- a/src/common/labelFormatters.js
+++ b/src/common/labelFormatters.js
@@ -2,18 +2,15 @@ import * as lodashString from 'lodash/string';
 
 // formats the label for the geographic type
 export const entityTypeDisplay = (entityType, prettycase) => {
-  if (entityType === 'nypd_precinct') {
-    return 'NYPD Precinct';
+  const typename = entityType.replace(/_/g, ' ');
+  const giveback = prettycase ? lodashString.startCase(lodashString.camelCase(typename)) : typename;
+
+  switch (entityType) {
+    case 'nypd_precinct':
+      return 'NYPD Precinct';
+    default:
+      return giveback;
   }
-  if (
-    entityType !== 'neighborhood' &&
-    entityType !== 'borough' &&
-    entityType !== 'community_board'
-  ) {
-    const typename = entityType.replace(/_/g, ' ');
-    return prettycase ? lodashString.startCase(lodashString.camelCase(typename)) : typename;
-  }
-  return '';
 };
 
 // formats the label for the entity key/id

--- a/src/components/DotGridCharts/DotGridChartsContainer.jsx
+++ b/src/components/DotGridCharts/DotGridChartsContainer.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import * as pt from '../../common/reactPropTypeDefs';
-import entityTypeDisplay, { entityIdDisplay } from '../../common/labelFormatters';
+import { entityTypeDisplay, entityIdDisplay } from '../../common/labelFormatters';
 import DotGridWrapper from '../../containers/DotGridWrapper';
 import DotGridTitle from './DotGridTitle';
 

--- a/src/components/Legend/EntitySelections.jsx
+++ b/src/components/Legend/EntitySelections.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import EntitySelector from './EntitySelector';
 import * as pt from '../../common/reactPropTypeDefs';
 import styleVars from '../../common/styleVars';
-import entityTypeDisplay, { entityIdDisplay } from '../../common/labelFormatters';
+import { entityTypeDisplay, entityIdDisplay } from '../../common/labelFormatters';
 
 /**
  * Class that houses the Entity Selector components

--- a/src/components/LineCharts/LineChart.jsx
+++ b/src/components/LineCharts/LineChart.jsx
@@ -5,7 +5,11 @@ import * as d3 from 'd3';
 import * as pt from '../../common/reactPropTypeDefs';
 import { formatDate, formatNumber } from '../../common/d3Utils';
 import styleVars from '../../common/styleVars';
-import entityTypeDisplay from '../../common/labelFormatters';
+import {
+  entityTypeDisplay,
+  entityIdDisplay,
+  REFERENCE_ENTITY_NAMES,
+} from '../../common/labelFormatters';
 
 /** Class that renders the line chart for selected geographic entities using D3
 */
@@ -51,7 +55,7 @@ class LineChart extends Component {
 
     this.container = null; // ref to containing div
     this.svg = null; // ref to svg element
-    this.margin = { top: 10, right: 50, bottom: 20, left: 25 };
+    this.margin = { top: 10, right: 75, bottom: 20, left: 60 };
 
     this.yAxis = d3.axisLeft();
     this.yAxis2 = d3.axisRight();
@@ -104,10 +108,13 @@ class LineChart extends Component {
       keySecondary,
       keyReference,
       referenceValues,
+      entityType,
       startDate,
       endDate,
       yMax,
       y2Max,
+      secondaryColor,
+      referenceColor,
     } = this.props;
 
     // a truthy value to use to tell if our chart has been set up yet
@@ -148,6 +155,36 @@ class LineChart extends Component {
       if (appHeight !== prevProps.appHeight || appWidth !== prevProps.appWidth) {
         this.resizeChart();
       }
+    }
+
+    // update the Y axis labels to show the names of the selected areas
+    if (chartExists) {
+      // axis label 2 (right side) is either the secondary or reference area
+      // reference area needs some hacks to cosmetically fix the names
+      // secondaries may need prefix + formatting e.g. "6" to "Council District 06"
+      const entityLabel = entityTypeDisplay(entityType, true);
+
+      let label2 = '';
+      if (keySecondary) {
+        label2 = `${entityLabel} ${entityIdDisplay(entityType, keySecondary)}`;
+      } else {
+        label2 = REFERENCE_ENTITY_NAMES[keyReference];
+      }
+
+      // axis label 1 (left side) may be empty
+      // secondaries may need prefix + formatting e.g. "6" to "Cuty Council District 06"
+      let label1 = '';
+      if (keyPrimary) {
+        label1 = `${entityLabel} ${entityIdDisplay(entityType, keyPrimary)}`;
+      }
+
+      this.yAxisLabel1.text(label1);
+      this.yAxisLabel2.text(label2);
+
+      // axis label 2 (right side) may be a secondary or a reference area
+      // change its color now to suit, either the secondaryColor or referenceColor
+      const color2 = keySecondary ? secondaryColor : referenceColor;
+      this.yAxisLabel2.attr('fill', color2);
     }
   }
 
@@ -553,6 +590,7 @@ class LineChart extends Component {
   initChart() {
     // initially render / set up the chart with, scales, axises, & grid lines; but no lines
     const { period, referenceValues, referenceColor, y2Max, startDate, endDate } = this.props;
+    const { primaryColor, secondaryColor } = this.props;
     const { width, height } = this.getContainerSize();
     const margin = this.margin;
     const xScale = this.xScale;
@@ -562,6 +600,10 @@ class LineChart extends Component {
     const yAxis2 = this.yAxis2;
     const xAxis = this.xAxis;
     const svg = d3.select(this.svg);
+
+    const yAxisLabelFontSize = '15px';
+    const yAxisLabelLetterSpacing = 0.1;
+    const yAxisLabelRotation = -90; // 90 or -90
 
     // set dimensions of the svg element
     svg
@@ -577,6 +619,26 @@ class LineChart extends Component {
     xAxis.scale(xScale);
     yAxis.scale(yScale);
     yAxis2.scale(yScale2);
+
+    // labels for the axes
+    this.yAxisLabel1 = svg
+      .append('g')
+      .attr('transform', `translate(15, ${height * 0.66})`)
+      .append('text')
+      .attr('transform', `rotate(${yAxisLabelRotation})`)
+      .attr('fill', primaryColor)
+      .attr('font-size', yAxisLabelFontSize)
+      .attr('letter-spacing', yAxisLabelLetterSpacing)
+      .text(''); // render() sets axis label dynamically
+    this.yAxisLabel2 = svg
+      .append('g')
+      .attr('transform', `translate(${width + margin.left + margin.right - 20}, ${height * 0.66})`)
+      .append('text')
+      .attr('transform', `rotate(${yAxisLabelRotation})`)
+      .attr('fill', secondaryColor)
+      .attr('font-size', yAxisLabelFontSize)
+      .attr('letter-spacing', yAxisLabelLetterSpacing)
+      .text(''); // render() sets axis label dynamically
 
     // main svg group element
     const g = svg

--- a/src/containers/RankCardsList.jsx
+++ b/src/containers/RankCardsList.jsx
@@ -8,7 +8,7 @@ import rankedListSelector from '../common/reduxSelectorsRankedList';
 import toggleEntity from '../common/toggleEntity';
 import * as pt from '../common/reactPropTypeDefs';
 import styleVars from '../common/styleVars';
-import entityTypeDisplay, { entityIdDisplay } from '../common/labelFormatters';
+import { entityTypeDisplay, entityIdDisplay } from '../common/labelFormatters';
 
 import RankCard from '../components/RankCards/RankCard';
 

--- a/src/containers/ReferenceEntitySelect.jsx
+++ b/src/containers/ReferenceEntitySelect.jsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 
 import * as pt from '../common/reactPropTypeDefs';
 import { setReferenceEntity, fetchEntityData } from '../actions';
+import { REFERENCE_ENTITY_NAMES } from '../common/labelFormatters';
 
 const mapStateToProps = ({ entities, data, customGeography }) => ({
   reference: entities.reference,
@@ -78,15 +79,15 @@ class ReferenceEntitySelect extends Component {
     const { reference } = this.props;
     const { customGeography } = this.props;
     const options = [
-      { value: 'citywide', label: 'Citywide' },
-      { value: 'manhattan', label: 'Manhattan' },
-      { value: 'bronx', label: 'The Bronx' },
-      { value: 'brooklyn', label: 'Brooklyn' },
-      { value: 'queens', label: 'Queens' },
-      { value: 'staten island', label: 'Staten Island' },
+      { value: 'citywide', label: REFERENCE_ENTITY_NAMES.citywide },
+      { value: 'manhattan', label: REFERENCE_ENTITY_NAMES.manhattan },
+      { value: 'bronx', label: REFERENCE_ENTITY_NAMES.bronx },
+      { value: 'brooklyn', label: REFERENCE_ENTITY_NAMES.brooklyn },
+      { value: 'queens', label: REFERENCE_ENTITY_NAMES.queens },
+      { value: 'staten island', label: REFERENCE_ENTITY_NAMES['staten island'] },
     ];
     if (customGeography.length) {
-      options.push({ value: 'custom', label: 'Custom Geography' });
+      options.push({ value: 'custom', label: REFERENCE_ENTITY_NAMES.custom });
     }
 
     return (

--- a/src/containers/SelectAreasList.jsx
+++ b/src/containers/SelectAreasList.jsx
@@ -8,7 +8,7 @@ import toggleEntity from '../common/toggleEntity';
 import { entityDataSelector } from '../common/reduxSelectors';
 import rankedListSelector from '../common/reduxSelectorsRankedList';
 import * as pt from '../common/reactPropTypeDefs';
-import entityTypeDisplay, { entityIdDisplay } from '../common/labelFormatters';
+import { entityTypeDisplay, entityIdDisplay } from '../common/labelFormatters';
 
 const mapStateToProps = state => {
   const { entities, filterType } = state;


### PR DESCRIPTION
This is the PR to resolve issue #67   It adds labels to the two Y axes of the Trend chart, with the name of the areas being compared (if there are two) or else the name of the reference area (if there's 1 or 0).

Includes an adjustment to `entityTypeDisplay()` to hand back the entity name in *Pretty Title Case* instead of just *lower case*

Includes a refactoring of REFERENCE_ENTITY_NAMES which defines the pretty names of the benchmark areas. Now that these are used in 2 places, it makes sense to have a universally-known mapping for e.g. 'bronx' to become 'The Bronx'
