### PR TITLE
#75 background ui-grey changed

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -27,7 +27,7 @@ $grey-light: #989898 !default;
 $grey-lighter: #f6f5f6 !default;
 $medium-grey: lighten($dark-grey, 50) !default;
 $bg-grey: #f5f5f3 !default;
-$ui-grey: rgba($grey, 0.8) !default;
+$ui-grey: rgba(0, 0, 0, 0.6) !default;
 $transparent: rgba(0, 0, 0, 0) !default;
 $tooltip-grey: darken($dark-grey, 10%) !default;
 


### PR DESCRIPTION
A single change, to implement the new background color per https://github.com/GreenInfo-Network/nyc-crash-mapper-chart-view/issues/75
