### PR TITLE
implements #96 Compare view add total K/I sums

### DIFF
--- a/scss/components/_dot-grid-sums.scss
+++ b/scss/components/_dot-grid-sums.scss
@@ -1,0 +1,15 @@
+.DotGridSums {
+  width: 50%;
+  height: auto;
+  display: inline-block;
+  vertical-align: top;
+  padding: 0;
+  margin: 0;
+  text-transform: uppercase;
+  color: #ddd;
+
+  &:last-child {
+    padding-right: 0;
+    padding-left: 10px;
+  }
+}

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -37,6 +37,7 @@
 @import 'components/dot-grid-charts-container';
 @import 'components/dot-grid-chart';
 @import 'components/dot-grid-wrapper';
+@import 'components/dot-grid-sums';
 @import 'components/dot-grid-title';
 @import 'components/timeline';
 @import 'components/legend';

--- a/src/components/DotGridCharts/DotGridChartsContainer.jsx
+++ b/src/components/DotGridCharts/DotGridChartsContainer.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import * as pt from '../../common/reactPropTypeDefs';
 import { entityTypeDisplay, entityNameDisplay } from '../../common/labelFormatters';
 import DotGridWrapper from '../../containers/DotGridWrapper';
+import DotGridSums from '../../containers/DotGridSums';
 import DotGridTitle from './DotGridTitle';
 
 /**
@@ -46,6 +47,12 @@ class DotGridChartsContainer extends Component {
           />
         ) : null}
 
+        {customGeography.length ? (
+          <div className="dot-grid-row">
+            <DotGridSums entityType={'custom'} period={'period1'} />
+            <DotGridSums entityType={'custom'} period={'period2'} />
+          </div>
+        ) : null}
         {customGeography.length ? (
           <div className="dot-grid-row">
             <DotGridWrapper
@@ -118,6 +125,12 @@ class DotGridChartsContainer extends Component {
         )}
         {keyPrimary && (
           <div className="dot-grid-row">
+            <DotGridSums entityType={'primary'} period={'period1'} />
+            <DotGridSums entityType={'primary'} period={'period2'} />
+          </div>
+        )}
+        {keyPrimary && (
+          <div className="dot-grid-row">
             <DotGridWrapper
               entityType={'primary'}
               period={'period1'}
@@ -179,6 +192,12 @@ class DotGridChartsContainer extends Component {
 
         {keySecondary && (
           <DotGridTitle keyLabel={keyLabelSecondary} {...{ keyPrimary, dateRanges, entityLabel }} />
+        )}
+        {keySecondary && (
+          <div className="dot-grid-row">
+            <DotGridSums entityType={'secondary'} period={'period1'} />
+            <DotGridSums entityType={'secondary'} period={'period2'} />
+          </div>
         )}
         {keySecondary && (
           <div className="dot-grid-row">

--- a/src/containers/DotGridSums.jsx
+++ b/src/containers/DotGridSums.jsx
@@ -1,0 +1,89 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+
+import { formatNumber } from '../common/d3Utils';
+
+import * as pt from '../common/reactPropTypeDefs';
+import {
+  dateRangesSelector,
+  primaryEntityValuesFilteredSelector,  // eslint-disable-line
+  secondaryEntityValuesFilteredSelector,  // eslint-disable-line
+  customGeographyValuesFilteredSelector,  // eslint-disable-line
+} from '../common/reduxSelectors';
+
+const mapStateToProps = (state, props) => {
+  const { filterType } = state;
+  const { entityType, period } = props;
+  const dateRange = dateRangesSelector(state, props);
+
+  let values = [];
+  switch (entityType) {
+    case 'primary':
+      values = primaryEntityValuesFilteredSelector(state, props);
+      break;
+    case 'secondary':
+      values = secondaryEntityValuesFilteredSelector(state, props);
+      break;
+    case 'custom':
+      values = customGeographyValuesFilteredSelector(state, props);
+      break;
+    default:
+      throw new Error('DotGridSums got unexpected entityType');
+  }
+
+  const totalinjured = values.reduce(
+    (sum, month) => sum + month.pedestrian_injured + month.cyclist_injured + month.motorist_injured,
+    0
+  );
+  const totalkilled = values.reduce(
+    (sum, month) => sum + month.pedestrian_killed + month.cyclist_killed + month.motorist_killed,
+    0
+  );
+
+  return {
+    filterType,
+    startDate: dateRange.startDate,
+    endDate: dateRange.endDate,
+    period,
+    entityType,
+    totalinjured,
+    totalkilled,
+  };
+};
+
+/*
+ * Class that wraps the Dot Grid Chart connecting it to parts of the Redux Store
+ * Unlike the Line Charts, each Dot Grid Chart gets a single geo entity, time period, and person type
+*/
+class DotGridSums extends Component {
+  static propTypes = {
+    entityType: pt.key.isRequired,
+    filterType: pt.filterType.isRequired,
+    period: PropTypes.string.isRequired,
+    startDate: pt.date.isRequired,
+    endDate: pt.date.isRequired,
+    totalinjured: PropTypes.number.isRequired,
+    totalkilled: PropTypes.number.isRequired,
+  };
+
+  static defaultProps = {
+    values: [],
+  };
+
+  render() {
+    const { totalinjured, totalkilled } = this.props;
+
+    return (
+      <div className="DotGridSums">
+        <h6>
+          persons killed: {formatNumber(totalkilled)}
+          <br />
+          persons injured: {formatNumber(totalinjured)}
+        </h6>
+      </div>
+    );
+  }
+}
+
+export default connect(mapStateToProps, null)(DotGridSums);

--- a/src/containers/DotGridSums.jsx
+++ b/src/containers/DotGridSums.jsx
@@ -32,14 +32,21 @@ const mapStateToProps = (state, props) => {
       throw new Error('DotGridSums got unexpected entityType');
   }
 
-  const totalinjured = values.reduce(
-    (sum, month) => sum + month.pedestrian_injured + month.cyclist_injured + month.motorist_injured,
-    0
-  );
-  const totalkilled = values.reduce(
-    (sum, month) => sum + month.pedestrian_killed + month.cyclist_killed + month.motorist_killed,
-    0
-  );
+  console.log([ 'GDA values=', values ]);  // eslint-disable-line
+  const totalinjured = values.reduce((sum, month) => {
+    let newadds = 0;
+    if (month.pedestrian_injured !== undefined) newadds += month.pedestrian_injured;
+    if (month.cyclist_injured !== undefined) newadds += month.cyclist_injured;
+    if (month.motorist_injured !== undefined) newadds += month.motorist_injured;
+    return sum + newadds;
+  }, 0);
+  const totalkilled = values.reduce((sum, month) => {
+    let newadds = 0;
+    if (month.pedestrian_killed !== undefined) newadds += month.pedestrian_killed;
+    if (month.cyclist_killed !== undefined) newadds += month.cyclist_killed;
+    if (month.motorist_killed !== undefined) newadds += month.motorist_killed;
+    return sum + newadds;
+  }, 0);
 
   return {
     filterType,


### PR DESCRIPTION
The `gda-96-comparesums` branch and this PR, implements the changes requested in https://github.com/GreenInfo-Network/nyc-crash-mapper-chart-view/issues/96   See that issue for screenshot.

* New `DotGridSums` component, based on DotGridChart code and styled like DotGridTitle
