### PR TITLE
#58 Compare persistent Citywide section

### DIFF
--- a/src/components/DotGridCharts/DotGridChart.jsx
+++ b/src/components/DotGridCharts/DotGridChart.jsx
@@ -53,36 +53,43 @@ const DotGridChart = props => {
   };
 
   // TO DO: replace SVG with Canvas? Boroughs take a while to render...
+  const chartTop = (
+    <div>
+      <PersonIcon className="PersonIcon" width="35px" height="35px" />
+      <div style={{ display: 'inline-block' }}>
+        <h6 style={killedTotalStyle}>
+          {`${personType} killed: `}
+          <strong>{formatNumber(killedTotal)}</strong>
+        </h6>
+        <h6 style={injuredTotalStyle}>
+          {`${personType} injured: `}
+          <strong>{formatNumber(injuredTotal)}</strong>
+        </h6>
+      </div>
+    </div>
+  );
+  const chartDots = props.drawdots ? (
+    <svg width={gridWidth} height={gridHeight + 10}>
+      <g transform={`translate(${translateFactor}, ${translateFactor})`}>
+        {grid.map((d, i) => (
+          <circle
+            key={i}
+            cx={d.x}
+            cy={d.y}
+            r={radius}
+            stroke={colorScale(personType)}
+            strokeWidth={strokeWidth}
+            fill={i + 1 <= killedTotal ? colorScale(personType) : 'none'}
+          />
+        ))}
+      </g>
+    </svg>
+  ) : null;
+
   return (
     <div className="DotGridChart">
-      <div>
-        <PersonIcon className="PersonIcon" width="35px" height="35px" />
-        <div style={{ display: 'inline-block' }}>
-          <h6 style={killedTotalStyle}>
-            {`${personType} killed: `}
-            <strong>{formatNumber(killedTotal)}</strong>
-          </h6>
-          <h6 style={injuredTotalStyle}>
-            {`${personType} injured: `}
-            <strong>{formatNumber(injuredTotal)}</strong>
-          </h6>
-        </div>
-      </div>
-      <svg width={gridWidth} height={gridHeight + 10}>
-        <g transform={`translate(${translateFactor}, ${translateFactor})`}>
-          {grid.map((d, i) => (
-            <circle
-              key={i}
-              cx={d.x}
-              cy={d.y}
-              r={radius}
-              stroke={colorScale(personType)}
-              strokeWidth={strokeWidth}
-              fill={i + 1 <= killedTotal ? colorScale(personType) : 'none'}
-            />
-          ))}
-        </g>
-      </svg>
+      {chartTop}
+      {chartDots}
     </div>
   );
 };
@@ -92,12 +99,14 @@ DotGridChart.propTypes = {
   radius: PropTypes.number,
   strokeWidth: PropTypes.number,
   data: PropTypes.shape({}),
+  drawdots: PropTypes.bool,
 };
 
 DotGridChart.defaultProps = {
   radius: 5,
   strokeWidth: 2,
   data: {},
+  drawdots: true,
 };
 
 export default DotGridChart;

--- a/src/components/DotGridCharts/DotGridChartsContainer.jsx
+++ b/src/components/DotGridCharts/DotGridChartsContainer.jsx
@@ -40,13 +40,72 @@ class DotGridChartsContainer extends Component {
 
     return (
       <div className="DotGridChartsContainer scroll">
+        <DotGridTitle keyLabel={'Citywide'} {...{ dateRanges, keyPrimary: '', entityLabel: '' }} />
+        <div className="dot-grid-row">
+          <DotGridSums entityType={'citywide'} period={'period1'} />
+          <DotGridSums entityType={'citywide'} period={'period2'} />
+        </div>
+        <div className="dot-grid-row">
+          <DotGridWrapper
+            entityType={'citywide'}
+            period={'period1'}
+            title={'Period A'}
+            radius={this.circleRadius}
+            strokeWidth={this.strokeWidth}
+            personType="pedestrian"
+          />
+          <DotGridWrapper
+            entityType={'citywide'}
+            period={'period2'}
+            title={'Period B'}
+            radius={this.circleRadius}
+            strokeWidth={this.strokeWidth}
+            personType="pedestrian"
+          />
+        </div>
+        <div className="dot-grid-row">
+          <DotGridWrapper
+            entityType={'citywide'}
+            period={'period1'}
+            title={'Period A'}
+            radius={this.circleRadius}
+            strokeWidth={this.strokeWidth}
+            personType="cyclist"
+          />
+          <DotGridWrapper
+            entityType={'citywide'}
+            period={'period2'}
+            title={'Period B'}
+            radius={this.circleRadius}
+            strokeWidth={this.strokeWidth}
+            personType="cyclist"
+          />
+        </div>
+        <div className="dot-grid-row">
+          <DotGridWrapper
+            entityType={'citywide'}
+            period={'period1'}
+            title={'Period A'}
+            radius={this.circleRadius}
+            strokeWidth={this.strokeWidth}
+            personType="motorist"
+          />
+          <DotGridWrapper
+            entityType={'citywide'}
+            period={'period2'}
+            title={'Period B'}
+            radius={this.circleRadius}
+            strokeWidth={this.strokeWidth}
+            personType="motorist"
+          />
+        </div>
+
         {customGeography.length ? (
           <DotGridTitle
             keyLabel={'Custom Geography'}
             {...{ dateRanges, keyPrimary: '', entityLabel: '' }}
           />
         ) : null}
-
         {customGeography.length ? (
           <div className="dot-grid-row">
             <DotGridSums entityType={'custom'} period={'period1'} />

--- a/src/containers/App.jsx
+++ b/src/containers/App.jsx
@@ -68,6 +68,7 @@ class App extends Component {
     const { entityType } = this.props;
     const { customGeography } = this.props;
 
+    // load the selected entity
     this.props.fetchEntityData(entityType);
 
     // we will be wanting this as our baselines for both Compare and Trend
@@ -75,6 +76,10 @@ class App extends Component {
     if (customGeography.length) {
       this.props.fetchEntityData('custom', customGeography);
     }
+
+    // as of issue 58, we want citywide data to be had for both Trend and Compare
+    // so start loading it now
+    this.props.fetchEntityData('citywide');
   }
 
   componentWillReceiveProps(nextProps) {

--- a/src/containers/DotGridSums.jsx
+++ b/src/containers/DotGridSums.jsx
@@ -7,9 +7,10 @@ import { formatNumber } from '../common/d3Utils';
 import * as pt from '../common/reactPropTypeDefs';
 import {
   dateRangesSelector,
-  primaryEntityValuesFilteredSelector,  // eslint-disable-line
-  secondaryEntityValuesFilteredSelector,  // eslint-disable-line
-  customGeographyValuesFilteredSelector,  // eslint-disable-line
+  primaryEntityValuesFilteredSelector,
+  secondaryEntityValuesFilteredSelector,
+  customGeographyValuesFilteredSelector,
+  referenceEntityValuesFilteredSelector,
 } from '../common/reduxSelectors';
 
 const mapStateToProps = (state, props) => {
@@ -25,6 +26,9 @@ const mapStateToProps = (state, props) => {
     case 'secondary':
       values = secondaryEntityValuesFilteredSelector(state, props);
       break;
+    case 'citywide':
+      values = referenceEntityValuesFilteredSelector(state, props);
+      break;
     case 'custom':
       values = customGeographyValuesFilteredSelector(state, props);
       break;
@@ -32,7 +36,6 @@ const mapStateToProps = (state, props) => {
       throw new Error('DotGridSums got unexpected entityType');
   }
 
-  console.log([ 'GDA values=', values ]);  // eslint-disable-line
   const totalinjured = values.reduce((sum, month) => {
     let newadds = 0;
     if (month.pedestrian_injured !== undefined) newadds += month.pedestrian_injured;

--- a/src/containers/DotGridWrapper.jsx
+++ b/src/containers/DotGridWrapper.jsx
@@ -10,6 +10,7 @@ import {
   primaryEntityValuesFilteredSelector,
   secondaryEntityValuesFilteredSelector,
   customGeographyValuesFilteredSelector,
+  referenceEntityValuesFilteredSelector,
 } from '../common/reduxSelectors';
 
 import DotGridChart from '../components/DotGridCharts/DotGridChart';
@@ -26,6 +27,9 @@ const mapStateToProps = (state, props) => {
       break;
     case 'secondary':
       values = secondaryEntityValuesFilteredSelector(state, props);
+      break;
+    case 'citywide':
+      values = referenceEntityValuesFilteredSelector(state, props);
       break;
     case 'custom':
       values = customGeographyValuesFilteredSelector(state, props);
@@ -219,6 +223,8 @@ class DotGridWrapper extends Component {
     const { radius, strokeWidth, personType } = this.props;
     const { valuesTransformed } = this.state;
 
+    const drawdots = this.props.entityType !== 'citywide'; // issue 58, dots not certain; skip if citywide
+
     return (
       <div
         className="DotGridWrapper"
@@ -226,7 +232,11 @@ class DotGridWrapper extends Component {
           this.chartContainer = _;
         }}
       >
-        <DotGridChart data={valuesTransformed} {...{ radius, strokeWidth, personType }} />
+        <DotGridChart
+          data={valuesTransformed}
+          drawdots={drawdots}
+          {...{ radius, strokeWidth, personType }}
+        />
       </div>
     );
   }


### PR DESCRIPTION
This branch `gda-58-comparecitywide` expands on the `gda-96-comparesums` branch and PR 97., to fulfill issue #58 so the Compare section has a persistent Citywide readout. Reviewing and merging PR96 and issue 96 first, may reduce the amount of code being reviewed here.

* DotGridChart component, reworked the `render()` method into two sections. The chart-dots section will be nulled if `props.drawdots` is *false*. This prop would be set in `DotGridWrapper` in the case of `entityType == citywide`.
* This new chart section was added into `DotGridChartsContainer`
* App.jsx now, on `componentDidMount()`, does a pull for citywide entity data (in addition to any selected comparison type), as we will be wanting citywide data in both Compare and Trend views even on initial page load.
