### PR TITLE
Crash Mapper issue 97 - Map and Chart cross-links

### DIFF
--- a/src/common/sqlQueries.js
+++ b/src/common/sqlQueries.js
@@ -88,11 +88,10 @@ export const sqlNameByGeoAndIdentifier = (geo, identifier) => {
   const namefield = sqlNameField(geo);
 
   let value = identifier;
-  const escaped = identifier.replace("'", "''");
 
   switch (geo) {
     case 'neighborhood':
-      value = `E'${escaped}'`;
+      value = `E'${identifier.replace("'", "''")}'`;
       break;
     default:
       break;

--- a/src/common/sqlQueries.js
+++ b/src/common/sqlQueries.js
@@ -87,17 +87,18 @@ export const sqlNameByGeoAndIdentifier = (geo, identifier) => {
   // as it appears in this Chart, e.g. district, 123 => "Borough, District Name 123"
   const namefield = sqlNameField(geo);
 
-  let value = identifier;
+  let queryvalue = typeof identifier === 'number' ? identifier.toString() : identifier;
+  const escaped = `E'${queryvalue.replace("'", "''")}'`;
 
   switch (geo) {
     case 'neighborhood':
-      value = `E'${identifier.replace("'", "''")}'`;
+      queryvalue = escaped;
       break;
     default:
       break;
   }
 
-  const sql = `SELECT ${namefield} AS areaname FROM crashes_all_prod WHERE ${geo}=${value}`;
+  const sql = `SELECT ${namefield} AS areaname FROM crashes_all_prod WHERE ${geo}=${queryvalue}`;
   return sql;
 };
 

--- a/src/containers/SelectAreasList.jsx
+++ b/src/containers/SelectAreasList.jsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
+import axios from 'axios';
 
 import { selectPrimaryEntity, selectSecondaryEntity } from '../actions';
 import toggleEntity from '../common/toggleEntity';
@@ -9,6 +10,7 @@ import { entityDataSelector } from '../common/reduxSelectors';
 import rankedListSelector from '../common/reduxSelectorsRankedList';
 import * as pt from '../common/reactPropTypeDefs';
 import { entityIdDisplay, entityNameDisplay } from '../common/labelFormatters';
+import { sqlNameByGeoAndIdentifier } from '../common/sqlQueries.js';
 
 const mapStateToProps = state => {
   const { entities, filterType } = state;
@@ -62,6 +64,51 @@ class SelectAreasList extends Component {
     super(props);
     this.renderListItems = this.renderListItems.bind(this);
     this.handleListItemClick = this.handleListItemClick.bind(this);
+  }
+
+  componentDidMount() {
+    const { primary, entityType, response } = this.props;
+
+    // hack re issue 97; try and resolve an entity identifier from the Map
+    // which uses a totally different format: just the numeric ID, just the neighborhood name, etc.
+    // and we need to convert that to Chart format e.g. "Borough, Full Area Name 123"
+    //
+    // &primary= is the area identifier, perhaps in Map format
+    // and it's not straightforward to know what areas are "Map format" cuz Chart format is free text
+    // and we may be reading URLs that don't need the &primary fixed, e.g. from Chart
+
+    let find_name_sql = '';
+    if (typeof primary.key === 'number') {
+      // all numeric = we know it needs to be resolved cuz it didn't come from Chart
+      // this is the majority of area types, when coming from Map
+      find_name_sql = sqlNameByGeoAndIdentifier(entityType, primary.key);
+    } else if (
+      entityType === 'neighborhood' &&
+      typeof primary.key === 'string' &&
+      primary.key.indexOf(',') === -1
+    ) {
+      // neighborhood and no comma = look up, Chart always adds borough-comma
+      find_name_sql = sqlNameByGeoAndIdentifier(entityType, primary.key);
+    }
+    // else, the name is fine as-is; basically this means borough and intersection
+
+    if (find_name_sql) {
+      axios({
+        method: 'get',
+        params: {
+          q: find_name_sql,
+        },
+      }).then(result => {
+        if (result.data.rows) {
+          const newidentifier = result.data.rows[0].areaname;
+
+          this.props.selectPrimaryEntity({
+            key: newidentifier,
+            values: response.filter(d => d[entityType] === entityType),
+          });
+        }
+      });
+    }
   }
 
   componentWillReceiveProps(nextProps) {


### PR DESCRIPTION
https://github.com/GreenInfo-Network/nyc-crash-mapper/issues/97

The chart app and map app have totally different ideas of identifying polygonal areas: `identifier` for the Map (the unique name/ID, e.g. *23*) and `primary` for the Chart (a unique but verbose string e.g. *Bronx, NYPD Precinct 123*) As a result, the Map links from Chart and the 3 Chart links from Map don't work as expected: they load the expected area type, but not the specific area and its data.

This PR will fix this, so the cross-links work properly.
* Coming from any chart to the Map, the data are filtered to the area and the map zooms to the area.
* Coming from the Map to any of the chart links, the area will be selected and data displayed.
